### PR TITLE
Introduce the either pattern

### DIFF
--- a/src/either.hxx
+++ b/src/either.hxx
@@ -1,0 +1,62 @@
+#ifndef _either_hxx_
+#define _either_hxx_
+
+#include <cassert>
+#include <ostream>
+#include <functional>
+
+using std::ostream;
+using std::function;
+
+template<class L,class R>
+class either {
+public:
+    static either<L,R> left (L l) { return either(&l,NULL); }
+    static either<L,R> right(R r) { return either(NULL,&r); }
+    bool isLeft () const { return (_l != NULL); }
+    bool isRight() const { return (_r != NULL); }
+    operator bool() { return isRight(); }
+    operator R() {
+        if(isRight())
+        {
+            return *_r;
+        } else {
+            throw std::runtime_error(*_l);
+        } }
+    L fromLeft  () const { assert(isLeft ()); return L(*_l); }
+    R fromRight () const { assert(isRight()); return R(*_r); }
+    ~either() {
+        if (_l != NULL) delete _l;
+        if (_r != NULL) delete _r;
+    }
+private:
+    L* _l; R* _r;
+    either(const L* l,const R* r) : _l(l != NULL ? new L(*l) : NULL)
+                                  , _r(r != NULL ? new R(*r) : NULL) {}
+};
+
+template<class L,class R>
+ostream& operator<<(ostream& out,const either<L,R> &e) {
+    if (e.isLeft())  out << "<Left:"  << e.fromLeft()  << ">";
+    if (e.isRight()) out << "<Right:" << e.fromRight() << ">";
+    return out;
+}
+
+template<class L,class R1, class R2>
+either<L,R2> Bind(either<L,R1> e,const function<either<L,R2>(R1)>& f) {
+    if (e.isLeft()) return either<L,R2>::left(e.fromLeft());
+    return f(e.fromRight());
+}
+
+template<class L,class R>
+either<L,R> Return(R r) {
+    return either<L,R>::right(r);
+}
+
+template<class L,class R1,class R2>
+either<L,R2> operator>>(either<L,R1>e,const function<either<L,R2>(R1)>&f) {
+    if (e.isLeft()) return either<L,R2>::left(e.fromLeft());
+    return f(e.fromRight());
+}
+
+#endif

--- a/src/either.hxx
+++ b/src/either.hxx
@@ -17,17 +17,25 @@ public:
     bool isRight() const { return (_r != NULL); }
     operator bool() { return isRight(); }
     operator R() {
-        if(isRight())
-        {
-            return *_r;
-        } else {
-            throw std::runtime_error(*_l);
-        } }
+            return fromRight();
+        }
     L fromLeft  () const { assert(isLeft ()); return L(*_l); }
-    R fromRight () const { assert(isRight()); return R(*_r); }
+    R fromRight () const {
+        if(isRight()) {
+            return R(*_r);
+        } else {
+            throw std::runtime_error(L(*_l));
+        }
+    }
     ~either() {
-        if (_l != NULL) delete _l;
-        if (_r != NULL) delete _r;
+        if(!std::is_pointer<L>())
+        {
+            if (_l != NULL) delete _l;
+        }
+        if(!std::is_pointer<R>())
+        {
+            if (_r != NULL) delete _r;
+        }
     }
 private:
     L* _l; R* _r;

--- a/src/either.hxx
+++ b/src/either.hxx
@@ -11,36 +11,41 @@ using std::function;
 template<class L,class R>
 class either {
 public:
-    static either<L,R> left (L l) { return either(&l,NULL); }
-    static either<L,R> right(R r) { return either(NULL,&r); }
-    bool isLeft () const { return (_l != NULL); }
-    bool isRight() const { return (_r != NULL); }
+    static either<L,R> left (L l) { return either(&l,NULL,false); }
+    static either<L,R> right(R r) { return either(NULL,&r,true); }
+
+    bool isLeft () const { return !_isRight; }
+    bool isRight() const { return _isRight; }
     operator bool() { return isRight(); }
     operator R() {
             return fromRight();
         }
-    L fromLeft  () const { assert(isLeft ()); return L(*_l); }
+    L fromLeft  () const { assert(isLeft ()); return _l; }
     R fromRight () const {
         if(isRight()) {
-            return R(*_r);
+            return _r;
         } else {
-            throw std::runtime_error(L(*_l));
+            throw std::runtime_error(_l);
         }
     }
-    ~either() {
-        if(!std::is_pointer<L>())
-        {
-            if (_l != NULL) delete _l;
-        }
-        if(!std::is_pointer<R>())
-        {
-            if (_r != NULL) delete _r;
-        }
-    }
+    ~either() {}
+
 private:
-    L* _l; R* _r;
-    either(const L* l,const R* r) : _l(l != NULL ? new L(*l) : NULL)
-                                  , _r(r != NULL ? new R(*r) : NULL) {}
+    bool _isRight;
+    L _l;
+    R _r;
+    either(const L* l,const R* r, bool isRight)
+        : _isRight(isRight)
+    {
+        if(isRight)
+        {
+            _r = R(*r);
+        }
+        else
+        {
+            _l = L(*l);
+        }
+    }
 };
 
 template<class L,class R>

--- a/src/safetinyxml.hxx
+++ b/src/safetinyxml.hxx
@@ -26,6 +26,23 @@ namespace mc_rbdyn_urdf
     };
   }
 
+  std::function<MaybeElement(tinyxml2::XMLElement*)>
+  nextSiblingElement(const std::string& tag)
+  {
+    return [&tag](tinyxml2::XMLElement * e)
+    {
+      auto res = e->NextSiblingElement(tag.c_str());
+      if(res)
+      {
+        return MaybeElement::right(res);
+      }
+      else
+      {
+        return MaybeElement::left("No child named " + tag);
+      }
+    };
+  }
+
   std::function<MaybeDouble(tinyxml2::XMLElement*)>
   doubleAttribute(const std::string& attr)
   {

--- a/src/safetinyxml.hxx
+++ b/src/safetinyxml.hxx
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "either.hxx"
+#include <tinyxml2.h>
+
+namespace mc_rbdyn_urdf
+{
+  using MaybeElement = either<std::string, tinyxml2::XMLElement*>;
+  using MaybeDouble = either<std::string, double>;
+
+  std::function<MaybeElement(tinyxml2::XMLElement*)>
+  firstChildElement(const std::string& tag)
+  {
+    return [&tag](tinyxml2::XMLElement * e)
+    {
+      auto res = e->FirstChildElement(tag.c_str());
+      if(res)
+      {
+        return MaybeElement::right(res);
+      }
+      else
+      {
+        return MaybeElement::left("No child named " + tag);
+      }
+    };
+  }
+
+  std::function<MaybeDouble(tinyxml2::XMLElement*)>
+  doubleAttribute(const std::string& attr)
+  {
+    return [attr](tinyxml2::XMLElement* elem)
+    {
+      return MaybeDouble::right(elem->DoubleAttribute(attr.c_str()));
+    };
+  }
+}

--- a/src/safetinyxml.hxx
+++ b/src/safetinyxml.hxx
@@ -7,6 +7,7 @@ namespace mc_rbdyn_urdf
 {
   using MaybeElement = either<std::string, tinyxml2::XMLElement*>;
   using MaybeDouble = either<std::string, double>;
+  using MaybeString = either<std::string, std::string>;
 
   std::function<MaybeElement(tinyxml2::XMLElement*)>
   firstChildElement(const std::string& tag)
@@ -31,6 +32,34 @@ namespace mc_rbdyn_urdf
     return [attr](tinyxml2::XMLElement* elem)
     {
       return MaybeDouble::right(elem->DoubleAttribute(attr.c_str()));
+    };
+  }
+
+  std::function<MaybeDouble(tinyxml2::XMLElement*)>
+  doubleAttribute(const std::string& attr, double def)
+  {
+    return [attr, def](tinyxml2::XMLElement* elem)
+    {
+      double res = def;
+      elem->QueryDoubleAttribute(attr.c_str(), &res);
+      return MaybeDouble::right(res);
+    };
+  }
+
+  std::function<MaybeString(tinyxml2::XMLElement*)>
+  attribute(const std::string& attr)
+  {
+    return [attr](tinyxml2::XMLElement* elem)
+    {
+      auto ret = elem->Attribute(attr.c_str());
+      if(ret)
+      {
+        return MaybeString::right(ret);
+      }
+      else
+      {
+        return MaybeString::left("No attribute named " + attr);
+      }
     };
   }
 }

--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -89,7 +89,7 @@ Eigen::Matrix3d RPY(const std::vector<double> rpy)
   if(rpy.size() != 3)
   {
     std::cerr << "Cannot convert RPY vector of size " << rpy.size() << " to matrix" << std::endl;
-    throw(std::string("bad vector"));
+    throw(std::runtime_error("Bad vector"));
   }
   return RPY(rpy[0], rpy[1], rpy[2]);
 }

--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -204,9 +204,8 @@ std::string parseMultiBodyGraphFromURDF(URDFParserResult& res, const std::string
     std::vector<double> comRPY = {0.0, 0.0, 0.0};
     Eigen::Matrix3d inertia_o = Eigen::Matrix3d::Zero();
 
-    MaybeElement inertialDom  = MaybeElement::right(linkDom->FirstChildElement("inertial"));
-    bool isVirtual = inertialDom;
-    if(not isVirtual)
+    MaybeElement inertialDom  = MaybeElement::right(linkDom) >> firstChildElement("inertial");
+    if(inertialDom)
     {
       MaybeElement originDom = inertialDom >> firstChildElement("origin");
       MaybeElement massDom = inertialDom >> firstChildElement("mass");

--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -26,6 +26,8 @@
 #include <cmath>
 #include <ciso646>
 
+#include "safetinyxml.hxx"
+
 namespace mc_rbdyn_urdf
 {
 
@@ -202,13 +204,13 @@ std::string parseMultiBodyGraphFromURDF(URDFParserResult& res, const std::string
     std::vector<double> comRPY = {0.0, 0.0, 0.0};
     Eigen::Matrix3d inertia_o = Eigen::Matrix3d::Zero();
 
-    tinyxml2::XMLElement * inertialDom = linkDom->FirstChildElement("inertial");
-    bool isVirtual = (inertialDom == 0);
+    MaybeElement inertialDom  = MaybeElement::right(linkDom->FirstChildElement("inertial"));
+    bool isVirtual = inertialDom;
     if(not isVirtual)
     {
-      tinyxml2::XMLElement * originDom = inertialDom->FirstChildElement("origin");
-      tinyxml2::XMLElement * massDom = inertialDom->FirstChildElement("mass");
-      tinyxml2::XMLElement * inertiaDom = inertialDom->FirstChildElement("inertia");
+      MaybeElement originDom = inertialDom >> firstChildElement("origin");
+      MaybeElement massDom = inertialDom >> firstChildElement("mass");
+      MaybeElement inertiaDom = inertialDom >> firstChildElement("inertia");
 
       if(originDom)
       {
@@ -216,7 +218,7 @@ std::string parseMultiBodyGraphFromURDF(URDFParserResult& res, const std::string
         comRPY = attrToList(*originDom, "rpy", {0.0, 0.0, 0.0});
       }
       Eigen::Matrix3d comFrame = RPY(comRPY);
-      mass = massDom->DoubleAttribute("value");
+      mass = inertialDom >> firstChildElement("mass") >> doubleAttribute("value");
       Eigen::Matrix3d inertia = readInertia(*inertiaDom);
       if(transformInertia)
       {

--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -306,11 +306,9 @@ std::string parseMultiBodyGraphFromURDF(URDFParserResult& res, const std::string
     rbd::Joint::Type type = rbdynFromUrdfJoint(jointType, (jointName.length() >= sphericalSuffix.length()
                             && jointName.substr(jointName.length() - sphericalSuffix.length(), sphericalSuffix.length()) == sphericalSuffix));
 
-    MaybeElement parentDom = jointDom >> firstChildElement("parent");
-    std::string jointParent = parentDom >> attribute("link");
+    std::string jointParent = jointDom >> firstChildElement("parent") >> attribute("link");
 
-    MaybeElement childDom = jointDom >> firstChildElement("child");
-    std::string jointChild = childDom >> attribute("link");
+    std::string jointChild = jointDom >> firstChildElement("child") >> attribute("link");
 
     rbd::Joint j(type, axis, true, jointName);
 


### PR DESCRIPTION
This is a proposition to fix #1 : introduce the either pattern. Basically, all raw `tinyxml::XMLElement *` will be replaced by `MaybeElement` that might hold a `right()` (i.e. correct) value or a `left()` (i.e. error) value. This allows to safely chain function applications, resulting in something like:
```cpp
double mass = inertialDom >> firstChildElement("mass") >> doubleAttribute("value");
```
being valid, and safe. If everything went well, it will return the proper value. Else, it will panic, indicating at which step the computation failed.

Note for haskellers: we should really be using `>>=`, but its associativity is a problem in this context.