### PR TITLE
Option for SIMD compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cmake"]
 	path = cmake
 	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git
-[submodule ".jrl-ci"]
-	path = .jrl-ci
-	url = https://github.com/gergondet/jrl-travis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
 endif()
 option(PYTHON_BINDING_USER_INSTALL "Install the Python bindings in user space" ${PYTHON_BINDING_USER_INSTALL_DEFAULT})
 option(DISABLE_TESTS "Disable unit tests." OFF)
+option(ENABLE_SIMD "Build with all SIMD instructions on the current local machine" OFF)
 
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++0x -pedantic")

--- a/include/mc_rbdyn_urdf/urdf.h
+++ b/include/mc_rbdyn_urdf/urdf.h
@@ -100,7 +100,7 @@ MCRBDYNURDF_API Eigen::Vector3d attrToVector(const tinyxml2::XMLElement & dom, c
 
 MCRBDYNURDF_API Eigen::Matrix3d RPY(const double & r, const double & p, const double & y);
 
-MCRBDYNURDF_API rbd::Joint::Type rbdynFromUrdfJoint(const std::string & type);
+MCRBDYNURDF_API rbd::Joint::Type rbdynFromUrdfJoint(const std::string & type, bool hasSphericalSuffix = false);
 
 MCRBDYNURDF_API sva::PTransformd originFromTag(const tinyxml2::XMLElement & root, const std::string & tagName);
 MCRBDYNURDF_API sva::PTransformd originFromTag(const tinyxml2::XMLElement * dom);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,23 @@ set(HEADERS
 )
 
 add_library(mc_rbdyn_urdf SHARED ${SOURCES} ${HEADERS})
+
+if(ENABLE_SIMD)
+  if(MSVC)
+    target_compile_options(mc_rbdyn_urdf PUBLIC /arch:SSE2 /arch:AVX /arch:AVX2)
+  elseif(CMAKE_COMPILER_IS_GNUCXX)
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+    set(CXX_COMPILER_VERSION ${GCC_VERSION})
+    target_compile_options(mc_rbdyn_urdf PUBLIC -march=native)
+    if(GCC_VERSION VERSION_GREATER 7.0)
+      target_compile_options(mc_rbdyn_urdf PUBLIC -faligned-new)
+    endif()
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(mc_rbdyn_urdf PUBLIC -march=native -faligned-new)
+  endif()
+endif()
+
 pkg_config_use_dependency(mc_rbdyn_urdf RBDyn)
 pkg_config_use_dependency(mc_rbdyn_urdf tinyxml2)
 

--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -101,7 +101,7 @@ inline Eigen::Matrix3d readInertia(const tinyxml2::XMLElement & dom)
   return m;
 }
 
-rbd::Joint::Type rbdynFromUrdfJoint(const std::string & type, bool hasSphericalSuffix = false)
+rbd::Joint::Type rbdynFromUrdfJoint(const std::string & type, bool hasSphericalSuffix)
 {
   if(type == "revolute")
     return rbd::Joint::Rev;


### PR DESCRIPTION
In some of my projects I am using Eigen compiled with SIMD instructions (`-march=native`) and as such I need your library compiled with the same instructions. This PR adds a CMake option to do so: disabled by default to not break anything.