### PR TITLE
Fix assumption on global locale in URDF parser

### DIFF
--- a/src/urdf.cpp
+++ b/src/urdf.cpp
@@ -11,6 +11,7 @@
 #include <ciso646>
 #include <cmath>
 #include <iostream>
+#include <locale>
 #include <tinyxml2.h>
 
 namespace mc_rbdyn_urdf
@@ -25,6 +26,12 @@ std::vector<double> attrToList(const tinyxml2::XMLElement & dom,
   if(attrTxt)
   {
     std::stringstream ss;
+    // Every real number in a URDF file needs to be parsed assuming that the
+    // decimal point separator is the period, as specified in XML Schema
+    // definition of xs:double. The call to imbue ensures that a suitable
+    // locale is used, instead of using the current C++ global locale.
+    // Related PR: https://github.com/ros/urdfdom_headers/pull/42 .
+    ss.imbue(std::locale::classic());
     ss << attrTxt;
     double tmp;
     while(ss.good())


### PR DESCRIPTION
Before this fix, the URDF parser was silently failing to parse the decimal part of any real number parsed from XML if the C++ global locale was set to have a decimal separator different from the point.

Related issues in other projects :
* https://github.com/ros/urdfdom/issues/98
* https://github.com/robotology/idyntree/issues/288
* https://bitbucket.org/osrf/sdformat/issues/60
* https://github.com/RobotLocomotion/drake/pull/10326